### PR TITLE
Zimoz/fix root center in screen

### DIFF
--- a/src/sim/simulation/sim.py
+++ b/src/sim/simulation/sim.py
@@ -301,8 +301,8 @@ class GrowingSim(Window):
         self.set_viewport(
             self.root_midpointx - SCREEN_WIDTH / 2,
             self.root_midpointx + SCREEN_WIDTH / 2,
-            self.root_tip_y - SCREEN_HEIGHT/8,
-            self.root_tip_y - SCREEN_HEIGHT/3 + SCREEN_HEIGHT,
+            self.root_tip_y - SCREEN_HEIGHT / 8,
+            self.root_tip_y - SCREEN_HEIGHT / 3 + SCREEN_HEIGHT,
         )
 
     def on_update(self, delta_time: float) -> None:


### PR DESCRIPTION
resolves #17 

- change the parameters in set_viewport() function in update_viewport_position() in simulation
- make the screen to keep track of the center of the root